### PR TITLE
Fix custom key bindings not being loaded properly

### DIFF
--- a/common/src/main/java/com/euphony/better_client/mixin/OptionsMixin.java
+++ b/common/src/main/java/com/euphony/better_client/mixin/OptionsMixin.java
@@ -17,7 +17,7 @@ public class OptionsMixin implements IOptions {
     @Unique
     private OptionInstance<Boolean> better_client$pauseMusic;
 
-    @Inject(method = "<init>", at = @At("TAIL"))
+    @Inject(method = "<init>", at = @At("CTOR_HEAD"))
     public void init(Minecraft minecraft, File file, CallbackInfo ci) {
         this.better_client$pauseMusic = OptionInstance.createBoolean("options.pauseMusic", true);
     }


### PR DESCRIPTION
## About the PR
If the player changes the Minecraft key bindings, then at next start of the game with Better Client, those key binding changes are ignored and the default bindings are loaded instead.

This PR fixes this, so that the key bindings of the options.txt file are loaded.

## Steps to reproduce:
1. Change some key bindings, for example set sneaking to "c" and jumping to "y".
2. Restart the game.
3. Notice that right after loading into a map, "c" won't make you sneak and "y" won't make you jump.
Instead sneaking is still at the default "shift" key and jumping is still on the default "spacebar" key.
4. Go into the key binding settings.
Here you'll notice that the key bindings are still "c" = sneak and "y" = jump.
5. Edit the sneak key, but just save it as "c" again.
Notice how now *ALL* custom key bindings are working correctly again (c = sneak and y = jump).
6. But as soon as we restart the game, the default key bindings will be loaded again.

After the change from this PR, the key bindings will always be correctly loaded from the options.txt file.

## Technical details
For some reason, injecting the pause-music option at the TAIL end of the vanilla Options' constructor will lead to this behavior.
The last line in the constructor calls `this.load()`, which reads in the "options.txt" file.
So perhaps setting the pause-music option *after* that somehow makes Minecraft use the default keybindings.
But I'm not quite sure why.

Regardless though, changing the injection point to the beginning of the contructor (i.e. "CTOR_HEAD") fixes this.

## Notes
I have only tested this with Fabric.